### PR TITLE
feat: EIP-55 checksum addresses

### DIFF
--- a/commands/addr/bech_to_eth.go
+++ b/commands/addr/bech_to_eth.go
@@ -1,10 +1,10 @@
 package addr
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/btcsuite/btcutil/bech32"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +24,8 @@ var BechToEthCmd = &cobra.Command{
 			_ = fmt.Errorf("Error: %v\n", err)
 			return err
 		}
-		fmt.Printf("converted: 0x%s\n", hex.EncodeToString(converted))
+		addr := common.BytesToAddress(converted)
+		fmt.Printf("converted: %s\n", addr.Hex())
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary
- return EIP-55 checksum addresses in `addr bech-to-eth`

**Before:** 
```shell
$ gadget bech-to-eth cosmosvaloper1cml96vmptgw99syqrrz8az79xer2pcgpqqyk2g
converted: 0xc6fe5d33615a1c52c08018c47e8bc53646a0e101
```

**After:** 
```shell
$ gadget bech-to-eth cosmosvaloper1cml96vmptgw99syqrrz8az79xer2pcgpqqyk2g
converted: 0xC6Fe5D33615a1C52c08018c47E8Bc53646A0E101
```